### PR TITLE
Adding new parameter to JUDIOptions

### DIFF
--- a/src/TimeModeling/Modeling/python_interface.jl
+++ b/src/TimeModeling/Modeling/python_interface.jl
@@ -76,7 +76,7 @@ function devito_interface(modelPy::PyObject, srcGeometry::Geometry, srcData::Arr
     src_coords = setup_grid(srcGeometry, modelPy.shape)
 
     # Devito call
-    return wrapcall_wf(ac."forward_no_rec", modelPy, src_coords, qIn, fw=fw, space_order=options.space_order, illum=illum)
+    return wrapcall_wf(ac."forward_no_rec", modelPy, src_coords, qIn, fw=fw, space_order=options.space_order, illum=illum, par=options.par)
 end
 
 # d_obs = Pr*F*u
@@ -89,7 +89,7 @@ function devito_interface(modelPy::PyObject, srcGeometry::Nothing, srcData::Arra
     rec_coords = setup_grid(recGeometry, modelPy.shape)
 
     # Devito call
-    return wrapcall_data(ac."forward_wf_src", modelPy, srcData, rec_coords, fw=fw, space_order=options.space_order, f0=options.f0, illum=illum)
+    return wrapcall_data(ac."forward_wf_src", modelPy, srcData, rec_coords, fw=fw, space_order=options.space_order, f0=options.f0, illum=illum, par=options.par)
 end
 
 # u_out = F*u_in
@@ -99,7 +99,7 @@ function devito_interface(modelPy::PyObject, srcGeometry::Nothing, srcData::Arra
     dtComp = convert(Float32, modelPy."critical_dt")
 
     # Devito call
-    return wrapcall_wf(ac."forward_wf_src_norec", modelPy, srcData, fw=fw, space_order=options.space_order, illum=illum)
+    return wrapcall_wf(ac."forward_wf_src_norec", modelPy, srcData, fw=fw, space_order=options.space_order, illum=illum, par=options.par)
 end
 
 # d_lin = J*dm
@@ -156,7 +156,7 @@ function devito_interface(modelPy::PyObject, weights::Array, srcData::Array, rec
 
     # Devito call
     return wrapcall_data(ac."forward_rec_w", modelPy, weights, qIn, rec_coords,
-                         fw=fw, space_order=options.space_order, f0=options.f0, illum=illum)
+                         fw=fw, space_order=options.space_order, f0=options.f0, illum=illum, par=options.par)
 end
 
 # dw = Pw*F'*Pr'*d_obs - adjoint modeling w/ extended source

--- a/src/TimeModeling/Modeling/python_interface.jl
+++ b/src/TimeModeling/Modeling/python_interface.jl
@@ -62,7 +62,7 @@ function devito_interface(modelPy::PyObject, srcGeometry::Geometry, srcData::Arr
     rec_coords = setup_grid(recGeometry, modelPy.shape)
 
     # Devito call
-    return wrapcall_data(ac."forward_rec", modelPy, src_coords, qIn, rec_coords, fw=fw, space_order=options.space_order, f0=options.f0, illum=illum)
+    return wrapcall_data(ac."forward_rec", modelPy, src_coords, qIn, rec_coords, fw=fw, space_order=options.space_order, f0=options.f0, illum=illum, par=options.par)
 end
 
 # u = F*Ps'*q

--- a/src/TimeModeling/Types/OptionsStructure.jl
+++ b/src/TimeModeling/Types/OptionsStructure.jl
@@ -23,6 +23,7 @@ mutable struct JUDIOptions
     return_array::Bool
     dt_comp::Union{Float32, Nothing}
     f0::Float32
+    par::String
 end
 
 """
@@ -83,6 +84,8 @@ Options structure for seismic modeling.
 
 `f0`: define peak frequency.
 
+`par`: define parameter for the C_Matrix model in elastic_kernel
+
 Constructor
 ==========
 
@@ -96,7 +99,7 @@ All arguments are optional keyword arguments with the following default values:
             num_checkpoints=nothing, checkpoints_maxmem=nothing,
             frequencies=[], isic=false,
             subsampling_factor=1, dft_subsampling_factor=1, return_array=false,
-            dt_comp=nothing, f0=0.015f0)
+            dt_comp=nothing, f0=0.015f0, par="lam-mu")
 
 """
 Options(;space_order=8,
@@ -117,6 +120,7 @@ Options(;space_order=8,
          return_array=false,
          dt_comp=nothing,
          f0=0.015f0,
+         par="lam-mu",
          IC="as") =
 		 JUDIOptions(space_order,
 		 		 free_surface,
@@ -133,7 +137,8 @@ Options(;space_order=8,
 				 dft_subsampling_factor,
                  return_array,
                  dt_comp,
-                 f0)
+                 f0,
+                 par)
 
 JUDIOptions(;kw...) = Options(kw...)
 

--- a/src/TimeModeling/Types/OptionsStructure.jl
+++ b/src/TimeModeling/Types/OptionsStructure.jl
@@ -84,7 +84,7 @@ Options structure for seismic modeling.
 
 `f0`: define peak frequency.
 
-`par`: define parameter for the C_Matrix model in elastic_kernel
+`par`: define parametrization for the elastic wave inversion.
 
 Constructor
 ==========

--- a/src/pysource/interface.py
+++ b/src/pysource/interface.py
@@ -14,8 +14,8 @@ from fields_exprs import wf_as_src
 
 
 # Forward wrappers Pr*F*Ps'*q
-def forward_rec(model, src_coords, wavelet, rec_coords, space_order=8, f0=0.015,
-                illum=False, fw=True, par='lam-mu'):
+def forward_rec(model, src_coords, wavelet, rec_coords, par, space_order=8, f0=0.015,
+                illum=False, fw=True):
     """
     Modeling of a point source with receivers Pr*F*Ps^T*q.
 
@@ -49,7 +49,7 @@ def forward_rec(model, src_coords, wavelet, rec_coords, space_order=8, f0=0.015,
 
 
 #  Pr*F*Pw'*w
-def forward_rec_w(model, weight, wavelet, rec_coords, space_order=8, f0=0.015,
+def forward_rec_w(model, weight, wavelet, rec_coords, par, space_order=8, f0=0.015,
                   illum=False, fw=True):
     """
     Forward modeling of an extended source with receivers  Pr*F*Pw^T*w
@@ -79,12 +79,12 @@ def forward_rec_w(model, weight, wavelet, rec_coords, space_order=8, f0=0.015,
         Shot record
     """
     rec, _, I, _ = forward(model, None, rec_coords, wavelet, save=False, ws=weight,
-                           space_order=space_order, f0=f0, illum=illum, fw=fw)
+                           space_order=space_order, f0=f0, illum=illum, fw=fw, par=par)
     return rec.data, getattr(I, "data", None)
 
 
 # F*Ps'*q
-def forward_no_rec(model, src_coords, wavelet, space_order=8, f0=0.015, illum=False,
+def forward_no_rec(model, src_coords, wavelet, par, space_order=8, f0=0.015, illum=False,
                    fw=True):
     """
     Forward modeling of a point source without receiver.
@@ -112,12 +112,12 @@ def forward_no_rec(model, src_coords, wavelet, space_order=8, f0=0.015, illum=Fa
         Wavefield
     """
     _, u, I, _ = forward(model, src_coords, None, wavelet, space_order=space_order,
-                         save=True, f0=f0, illum=illum, fw=fw)
+                         save=True, f0=f0, illum=illum, fw=fw, par=par)
     return u.data, getattr(I, "data", None)
 
 
 # Pr*F*u
-def forward_wf_src(model, u, rec_coords, space_order=8, f0=0.015, illum=False, fw=True):
+def forward_wf_src(model, u, rec_coords, par, space_order=8, f0=0.015, illum=False, fw=True):
     """
     Forward modeling of a full wavefield source Pr*F*u.
 
@@ -145,12 +145,12 @@ def forward_wf_src(model, u, rec_coords, space_order=8, f0=0.015, illum=False, f
     """
     wsrc = src_wavefield(model, u, fw=True)
     rec, _, I, _ = forward(model, None, rec_coords, None, space_order=space_order,
-                           qwf=wsrc, illum=illum, f0=f0, fw=fw)
+                           qwf=wsrc, illum=illum, f0=f0, fw=fw, par=par)
     return rec.data, getattr(I, "data", None)
 
 
 # F*u
-def forward_wf_src_norec(model, u, space_order=8, f0=0.015, illum=False, fw=True):
+def forward_wf_src_norec(model, u, par, space_order=8, f0=0.015, illum=False, fw=True):
     """
     Forward modeling of a full wavefield source without receiver F*u.
 
@@ -176,7 +176,7 @@ def forward_wf_src_norec(model, u, space_order=8, f0=0.015, illum=False, fw=True
     """
     wf_src = src_wavefield(model, u, fw=True)
     _, u, I, _ = forward(model, None, None, None, space_order=space_order, save=True,
-                         qwf=wf_src, f0=f0, illum=illum, fw=fw)
+                         qwf=wf_src, f0=f0, illum=illum, fw=fw, par=par)
     return u.data, getattr(I, "data", None)
 
 

--- a/src/pysource/interface.py
+++ b/src/pysource/interface.py
@@ -15,7 +15,7 @@ from fields_exprs import wf_as_src
 
 # Forward wrappers Pr*F*Ps'*q
 def forward_rec(model, src_coords, wavelet, rec_coords, space_order=8, f0=0.015,
-                illum=False, fw=True):
+                illum=False, fw=True, par='lam-mu'):
     """
     Modeling of a point source with receivers Pr*F*Ps^T*q.
 
@@ -44,7 +44,7 @@ def forward_rec(model, src_coords, wavelet, rec_coords, space_order=8, f0=0.015,
         Shot record
     """
     rec, _, I, _ = forward(model, src_coords, rec_coords, wavelet, save=False,
-                           space_order=space_order, f0=f0, illum=illum, fw=fw)
+                           space_order=space_order, f0=f0, illum=illum, fw=fw, par=par)
     return rec.data, getattr(I, "data", None)
 
 

--- a/src/pysource/kernels.py
+++ b/src/pysource/kernels.py
@@ -7,7 +7,7 @@ from FD_utils import laplacian, sa_tti
 from utils import D, S, vec, C_Matrix, gather
 
 
-def wave_kernel(model, u, fw=True, q=None, f0=0.015):
+def wave_kernel(model, u, fw=True, q=None, f0=0.015, par='lam-mu'):
     """
     Pde kernel corresponding the the model for the input wavefield
 
@@ -28,7 +28,7 @@ def wave_kernel(model, u, fw=True, q=None, f0=0.015):
     elif model.is_viscoacoustic:
         pde = SLS_2nd_order(model, u, fw=fw, q=q, f0=f0)
     elif model.is_elastic:
-        pde = elastic_kernel(model, u[0], u[1], fw=fw, q=q)
+        pde = elastic_kernel(model, u[0], u[1], fw=fw, q=q, par=par)
     else:
         pde = acoustic_kernel(model, u, fw=fw, q=q)
     return pde

--- a/src/pysource/kernels.py
+++ b/src/pysource/kernels.py
@@ -7,7 +7,7 @@ from FD_utils import laplacian, sa_tti
 from utils import D, S, vec, C_Matrix, gather
 
 
-def wave_kernel(model, u, fw=True, q=None, f0=0.015, par='lam-mu'):
+def wave_kernel(model, u, par="lam-mu", fw=True, q=None, f0=0.015):
     """
     Pde kernel corresponding the the model for the input wavefield
 
@@ -179,7 +179,7 @@ def tti_kernel(model, u1, u2, fw=True, q=None):
     return [first_stencil, second_stencil] + pdea
 
 
-def elastic_kernel(model, v, tau, fw=True, q=None, par='lam-mu'):
+def elastic_kernel(model, v, tau, par, fw=True, q=None):
     """
     Elastic wave equation time stepper
 

--- a/src/pysource/operators.py
+++ b/src/pysource/operators.py
@@ -73,7 +73,7 @@ class memoized_func(object):
 
 @memoized_func
 def forward_op(p_params, tti, visco, elas, space_order, fw, spacing, save, t_sub, fs,
-               pt_src, pt_rec, nfreq, dft_sub, ws, wr, full_q, nv_weights, illum):
+               pt_src, pt_rec, nfreq, dft_sub, ws, wr, full_q, nv_weights, illum, par='lam-mu'):
     """
     Low level forward operator creation, to be used through `propagator.py`
     Compute forward wavefield u = A(m)^{-1}*f and related quantities (u(xrcv))
@@ -103,7 +103,7 @@ def forward_op(p_params, tti, visco, elas, space_order, fw, spacing, save, t_sub
     wrec = extended_rec(model, wavelet if wr else None, u)
 
     # Set up PDE expression and rearrange
-    pde = wave_kernel(model, u, q=q, f0=Constant('f0'), fw=fw)
+    pde = wave_kernel(model, u, q=q, f0=Constant('f0'), fw=fw, par=par)
 
     # Setup source and receiver
     g_expr = geom_expr(model, u, src_coords=scords, nt=nt,

--- a/src/pysource/operators.py
+++ b/src/pysource/operators.py
@@ -73,7 +73,7 @@ class memoized_func(object):
 
 @memoized_func
 def forward_op(p_params, tti, visco, elas, space_order, fw, spacing, save, t_sub, fs,
-               pt_src, pt_rec, nfreq, dft_sub, ws, wr, full_q, nv_weights, illum, par='lam-mu'):
+               pt_src, pt_rec, nfreq, dft_sub, ws, wr, full_q, nv_weights, illum, par):
     """
     Low level forward operator creation, to be used through `propagator.py`
     Compute forward wavefield u = A(m)^{-1}*f and related quantities (u(xrcv))

--- a/src/pysource/propagators.py
+++ b/src/pysource/propagators.py
@@ -12,10 +12,10 @@ from devito.tools import as_tuple
 
 
 # Forward propagation
-def forward(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
+def forward(model, src_coords, rcv_coords, wavelet, par="lam-mu", space_order=8, save=False,
             qwf=None, return_op=False, freq_list=None, dft_sub=None,
             norm_wf=False, w_fun=None, ws=None, wr=None, t_sub=1, f0=0.015,
-            illum=False, fw=True, par='lam-mu', **kwargs):
+            illum=False, fw=True, **kwargs):
     """
     Low level propagator, to be used through `interface.py`
     Compute forward wavefield u = A(m)^{-1}*f and related quantities (u(xrcv))

--- a/src/pysource/propagators.py
+++ b/src/pysource/propagators.py
@@ -15,7 +15,7 @@ from devito.tools import as_tuple
 def forward(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
             qwf=None, return_op=False, freq_list=None, dft_sub=None,
             norm_wf=False, w_fun=None, ws=None, wr=None, t_sub=1, f0=0.015,
-            illum=False, fw=True, **kwargs):
+            illum=False, fw=True, par='lam-mu', **kwargs):
     """
     Low level propagator, to be used through `interface.py`
     Compute forward wavefield u = A(m)^{-1}*f and related quantities (u(xrcv))
@@ -37,7 +37,7 @@ def forward(model, src_coords, rcv_coords, wavelet, space_order=8, save=False,
                     model.is_elastic, space_order, fw, model.spacing, save,
                     t_sub, model.fs, src_coords is not None, rcv_coords is not None,
                     nfreq(freq_list), dft_sub, ws is not None,
-                    wr is not None, qwf is not None, nv_weights, illum)
+                    wr is not None, qwf is not None, nv_weights, illum, par=par)
 
     # Make kwargs
     kw = base_kwargs(model.critical_dt)


### PR DESCRIPTION
Updating wrapped forward methods calls to accept a new "par" option.
Setting default "par" parameter to "lam-mu" at the forward and wave_kernel methods.